### PR TITLE
Add additional logic to handle no feature exhibit

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -26,8 +26,8 @@ intro_button_slug.options.description = "Submit the slug of the Simple Page that
 
 ; Header Background Image
 index_background_image.type = "file"
-index_background_image.options.label = "Index Default Background Image"
-index_background_image.options.description = "Choose an image file to display below the default feature exploration on the index."
+index_background_image.options.label = "Default Featured Exploration Background Image"
+index_background_image.options.description = "Choose an image file to display below the default featured exploration on the home page."
 index_background_image.options.validators.count.validator = "Count"
 index_background_image.options.validators.count.options.max = "1"
 

--- a/config.ini
+++ b/config.ini
@@ -24,6 +24,13 @@ intro_button_slug.type = "text"
 intro_button_slug.options.label = "Homepage Intro Button Slug"
 intro_button_slug.options.description = "Submit the slug of the Simple Page that the intro button links to."
 
+; Header Background Image
+index_background_image.type = "file"
+index_background_image.options.label = "Index Default Background Image"
+index_background_image.options.description = "Choose an image file to display below the default feature exploration on the index."
+index_background_image.options.validators.count.validator = "Count"
+index_background_image.options.validators.count.options.max = "1"
+
 footer.type = "textarea"
 footer.options.label = "Footer text"
 footer.options.description = "Submit text you want to appear as the copy for the footer."

--- a/custom.php
+++ b/custom.php
@@ -30,4 +30,14 @@ function mall_sort_events($firstPeriodItem, $secondPeriodItem) {
         return;
     }
 }
+
+function default_index_bg()
+{
+    $headerImage = get_theme_option('index_background_image');
+    if ($headerImage) {
+        $storage = Zend_Registry::get('storage');
+        $headerImage = $storage->getUri($storage->getPathByType($headerImage, 'theme_uploads'));
+        return $headerImage;
+    }
+}
 ?>

--- a/index.php
+++ b/index.php
@@ -26,9 +26,9 @@
             <div id="featured-question" class="featured" style="background-image:url('<?php echo img('rome.jpg'); ?>')">
             <h1>
                 <span class="category">Featured Exploration</span>
-                <span class="title">No featured exploreation</span>
+                <span class="title">No Featured Exploration Selected</span>
             </h1>
-            <p>You can add one in the admin page.</p>
+            <p>Adminstrators can add one in the admin page.</p>
         </div>
         <?php endif; ?>
         

--- a/index.php
+++ b/index.php
@@ -9,12 +9,12 @@
         </div>
         
         <?php $featuredExhibit = exhibit_builder_random_featured_exhibit(); ?>
+        <?php if (!is_null($featuredExhibit)): ?>
         <?php $featuredExhibitId = $featuredExhibit->id; ?>
         <?php $featuredExhibitItem = get_records('Item', array('exhibit' => $featuredExhibitId, 'random' => true, 'has files' => true), 1); ?>
-        <?php $featuredExhibitImage = get_db()->getTable('File')->findWithImages($featuredExhibitItem[0]->id, 0); ?>
-                
-        <div id="featured-question" class="featured" style="background-image:url('<?php echo file_display_url($featuredExhibitImage, 'original'); ?>')">
-            
+        <?php $featuredExhibitImage = empty($featuredExhibitItem) ? NULL : get_db()->getTable('File')->findWithImages($featuredExhibitItem[0]->id, 0); ?>
+
+        <div id="featured-question" class="featured" style="background-image:url('<?php echo (!is_null($featuredExhibitImage) ? file_display_url($featuredExhibitImage, 'original') : img('rome.jpg')); ?>')">
             <h1>
                 <span class="category">Featured Exploration</span>
                 <span class="title"><?php echo $featuredExhibit->title; ?></span>
@@ -22,6 +22,15 @@
             <p><?php echo snippet($featuredExhibit->description, 0, 200); ?></p>
             <p class="jump-link"><?php echo exhibit_builder_link_to_exhibit($featuredExhibit, 'Read More', array('class' => 'button')); ?></p>
         </div>
+        <?php else: ?>
+            <div id="featured-question" class="featured" style="background-image:url('<?php echo img('rome.jpg'); ?>')">
+            <h1>
+                <span class="category">Featured Exploration</span>
+                <span class="title">No featured exploreation</span>
+            </h1>
+            <p>You can add one in the admin page.</p>
+        </div>
+        <?php endif; ?>
         
         <?php 
         $featuredPeople = get_records('Item', array(

--- a/index.php
+++ b/index.php
@@ -7,14 +7,20 @@
             <p><?php echo get_theme_option('intro'); ?></p>
             <p><a href="<?php echo get_theme_option('intro_button_slug'); ?>" class="button"><?php echo get_theme_option('intro_button'); ?></a></p>
         </div>
-        
+
+        <?php if ((get_theme_option('index_background_image') === null)): ?>
+        <?php $defaultBgImage = img('rome.jpg'); ?>
+        <?php else: ?>
+        <?php $defaultBgImage = default_index_bg();?>
+        <?php endif ?>
+
         <?php $featuredExhibit = exhibit_builder_random_featured_exhibit(); ?>
         <?php if (!is_null($featuredExhibit)): ?>
         <?php $featuredExhibitId = $featuredExhibit->id; ?>
         <?php $featuredExhibitItem = get_records('Item', array('exhibit' => $featuredExhibitId, 'random' => true, 'has files' => true), 1); ?>
         <?php $featuredExhibitImage = empty($featuredExhibitItem) ? NULL : get_db()->getTable('File')->findWithImages($featuredExhibitItem[0]->id, 0); ?>
 
-        <div id="featured-question" class="featured" style="background-image:url('<?php echo (!is_null($featuredExhibitImage) ? file_display_url($featuredExhibitImage, 'original') : img('rome.jpg')); ?>')">
+        <div id="featured-question" class="featured" style="background-image:url('<?php echo (!is_null($featuredExhibitImage) ? file_display_url($featuredExhibitImage, 'original') : $defaultBgImage); ?>')">
             <h1>
                 <span class="category">Featured Exploration</span>
                 <span class="title"><?php echo $featuredExhibit->title; ?></span>
@@ -23,7 +29,7 @@
             <p class="jump-link"><?php echo exhibit_builder_link_to_exhibit($featuredExhibit, 'Read More', array('class' => 'button')); ?></p>
         </div>
         <?php else: ?>
-            <div id="featured-question" class="featured" style="background-image:url('<?php echo img('rome.jpg'); ?>')">
+            <div id="featured-question" class="featured" style="background-image:url('<?php echo $defaultBgImage; ?>')">
             <h1>
                 <span class="category">Featured Exploration</span>
                 <span class="title">No Featured Exploration Selected</span>


### PR DESCRIPTION
Fix issue #1. Take into consideration that if one feature exhibit doesn't have any images, we use the placeholder image instead. The code can now handle situations:

- have one or more feature exhibits (randomly select one)
- have feature exhibits without images (use the default images)
- have no feature exhibits (the block still exists but shows no feature exhibits)

The [site](https://omeka-dev-2022.carleton.edu/cgmrdev/) now is in no feature exhibits mode. The default image is `rome.jpg` (same as that of Historical Map). I think the language and background image can definitely change. Want some input.